### PR TITLE
Add expense edit, update, month, and year views

### DIFF
--- a/app/Http/Controllers/Backend/ExpenseController.php
+++ b/app/Http/Controllers/Backend/ExpenseController.php
@@ -40,4 +40,44 @@ class ExpenseController extends Controller
         $today =  Expense::where('date',$date)->get();
         return view('backend.expense.today_expense', compact('today'));
     }
+
+    public function EditExpense($id){
+
+        $expense = Expense::findOrFail($id);
+        return view('backend.expense.edit_expense', compact('expense'));
+    }
+
+    public function UpdateExpense(Request $request){
+        
+        $expense_id = $request->id;
+        Expense::findOrFail($expense_id)->update([
+            'details' => $request->details,
+            'amount' => $request->amount,
+            'month' => $request->month,
+            'year' => $request->year,
+            'date' => $request->date,
+            'created_at' => Carbon::now(),
+        ]);
+
+        $notification = array(
+            'message' => 'Expense updated succesfully',
+            'alert-type' => 'success',
+        );
+
+        return redirect()->route('today.expense')->with($notification);
+    }
+
+    public function MonthExpense(){
+
+        $month = date("F");
+        $monthExpense =  Expense::where('month',$month)->get();
+        return view('backend.expense.month_expense', compact('monthExpense'));
+    }
+
+    public function YearExpense(){
+        
+        $year = date("Y");
+        $yearExpense =  Expense::where('year',$year)->get();
+        return view('backend.expense.year_expense', compact('yearExpense'));
+    }
 }

--- a/resources/views/backend/expense/edit_expense.blade.php
+++ b/resources/views/backend/expense/edit_expense.blade.php
@@ -1,0 +1,110 @@
+@extends('admin_dashboard')
+@section('admin')
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+
+<div class="content">
+
+                    <!-- Start Content-->
+                    <div class="container-fluid">
+
+                        <!-- start page title -->
+                        <div class="row">
+                            <div class="col-12">
+                                <div class="page-title-box">
+                                    <div class="page-title-right">
+                                        {{-- <ol class="breadcrumb m-0">
+                                            <li class="breadcrumb-item"><a href="javascript: void(0);">Add Employee</a></li>
+                                        </ol> --}}
+                                    </div>
+                                    <h4 class="page-title">Edit Expense</h4>
+                                </div>
+                            </div>
+                        </div>     
+                        <!-- end page title -->
+
+                        <div class="row">
+                            
+                            <div class="col-lg-8 col-xl-12">
+                                <div class="card">
+                                    <div class="card-body">
+                                        
+                                        
+                                            
+                                            <!-- end about me section content -->
+    
+                                            
+                                            <!-- end timeline content-->
+    
+                                            <div class="tab-pane" id="settings">
+                                                <form method="POST" action="{{ route('expense.update') }}" enctype="multipart/form-data">
+                                                    @csrf
+
+                                                    <input type="hidden" name="id" value="{{ $expense->id }}">
+
+                                                    <h5 class="mb-4 text-uppercase"><i class="mdi mdi-account-circle me-1"></i> Add Expense</h5>
+                                                    <div class="row">
+
+                                                        <div class="col-md-12">
+                                                            <div class="mb-3">
+                                                                <label for="name" class="form-label">Expense Detail</label>
+                                                                <textarea name="details" class="form-control" name="" id="example-textarea" rows="3">
+                                                                    {{ $expense->details }}
+                                                                </textarea>
+                                                            </div>
+                                                        </div>
+
+                                                        <div class="col-md-12">
+                                                            <div class="mb-3">
+                                                                <label for="name" class="form-label">Amount</label>
+                                                                <input type="text" name="amount" class="form-control" value="{{ $expense->amount }}">
+                                                            </div>
+                                                        </div>
+
+                                                        <div class="col-md-12">
+                                                            <div class="mb-3">
+                                                                
+                                                                <input type="hidden" name="date" class="form-control" value="{{ date('d-m-Y') }}">
+                                                            </div>
+                                                        </div>
+
+                                                        <div class="col-md-12">
+                                                            <div class="mb-3">
+                                                                
+                                                                <input type="hidden" name="month" class="form-control" value="{{ date('F') }}">
+                                                            </div>
+                                                        </div>
+
+                                                        <div class="col-md-12">
+                                                            <div class="mb-3">
+                                                                
+                                                                <input type="hidden" name="year" class="form-control" value="{{ date('Y') }}">
+                                                            </div>
+                                                        </div>
+                                                                                                          
+                                                        
+                                                    </div> <!-- end row --> 
+                                                    
+                                                    <div class="text-end">
+                                                        <button type="submit" class="btn btn-success waves-effect waves-light mt-2"><i class="mdi mdi-content-save"></i> Save</button>
+                                                    </div>
+                                                </form>
+                                            </div>
+                                            <!-- end settings content-->
+    
+                                        
+                                    </div>
+                                </div> <!-- end card-->
+
+                            </div> <!-- end col -->
+                        </div>
+                        <!-- end row-->
+
+                    </div> <!-- container -->
+
+                </div>
+
+
+
+
+@endsection

--- a/resources/views/backend/expense/month_expense.blade.php
+++ b/resources/views/backend/expense/month_expense.blade.php
@@ -17,7 +17,7 @@
                                             <a href="{{ route('add.expense') }}" class="btn btn-primary rounded-pill waves-effect waves-light">Add Expense</a>
                                         </ol>
                                     </div>
-                                    <h4 class="page-title">Today's Expense</h4>
+                                    <h4 class="page-title">Month Expense</h4>
                                 </div>
                             </div>
                         </div>     
@@ -25,8 +25,8 @@
 
 
                         @php
-                        $date = date("d-m-Y");
-                        $expense = App\Models\Expense::where('date',$date)->sum('amount');
+                        $month = date("F");
+                        $expensemonth = App\Models\Expense::where('month',$month)->sum('amount');
                         @endphp
 
 
@@ -36,8 +36,8 @@
                                     <div class="card-body">
                                         {{-- <h4 class="header-title">All Employees</h4> --}}
 
-                                        <h4 class="header-title">Today Expense</h4>
-                                        <h4 style="color: black; font-size: 30px;" align="center">Total : ₦{{ $expense }}</h4>
+                                        <h4 class="header-title">Month Expense</h4>
+                                        <h4 style="color: black; font-size: 30px;" align="center">Total : ₦{{ $expensemonth }}</h4>
                                         
 
                                         <table id="basic-datatable" class="table dt-responsive nowrap w-100">
@@ -47,24 +47,18 @@
                                                     <th>Details</th>
                                                     <th>Amount</th>
                                                     <th>Month</th>
-                                                    <th>Year</th>
-                                                    <th>Action</th>
                                                 </tr>
                                             </thead>
                                         
                                         
                                             <tbody>
-                                                @foreach ($today as $key=> $item)                                                    
+                                                @foreach ($monthExpense as $key=> $item)                                                    
                                                 <tr>
                                                     <td>{{ $key+1 }}</td>
                                                     
                                                     <td>{{ $item->details }}</td>
                                                     <td>{{ $item->amount }}</td>
                                                     <td>{{ $item->month }}</td>
-                                                    <td>{{ $item->year }}</td>
-                                                    <td>
-                                                        <a href="{{ route('edit.expense',$item->id) }}" class="btn btn-blue rounded-pill waves-effect waves-light">Edit</a>
-                                                    </td>
                                                 </tr>
                                                 @endforeach
                                             </tbody>

--- a/resources/views/backend/expense/year_expense.blade.php
+++ b/resources/views/backend/expense/year_expense.blade.php
@@ -17,7 +17,7 @@
                                             <a href="{{ route('add.expense') }}" class="btn btn-primary rounded-pill waves-effect waves-light">Add Expense</a>
                                         </ol>
                                     </div>
-                                    <h4 class="page-title">Today's Expense</h4>
+                                    <h4 class="page-title">Year Expense</h4>
                                 </div>
                             </div>
                         </div>     
@@ -25,8 +25,8 @@
 
 
                         @php
-                        $date = date("d-m-Y");
-                        $expense = App\Models\Expense::where('date',$date)->sum('amount');
+                        $year = date("Y");
+                        $expenseyear = App\Models\Expense::where('year',$year)->sum('amount');
                         @endphp
 
 
@@ -36,8 +36,8 @@
                                     <div class="card-body">
                                         {{-- <h4 class="header-title">All Employees</h4> --}}
 
-                                        <h4 class="header-title">Today Expense</h4>
-                                        <h4 style="color: black; font-size: 30px;" align="center">Total : ₦{{ $expense }}</h4>
+                                        <h4 class="header-title">Yearly Expense</h4>
+                                        <h4 style="color: black; font-size: 30px;" align="center">Total : ₦{{ $expenseyear }}</h4>
                                         
 
                                         <table id="basic-datatable" class="table dt-responsive nowrap w-100">
@@ -46,25 +46,19 @@
                                                     <th>Sl</th>
                                                     <th>Details</th>
                                                     <th>Amount</th>
-                                                    <th>Month</th>
                                                     <th>Year</th>
-                                                    <th>Action</th>
                                                 </tr>
                                             </thead>
                                         
                                         
                                             <tbody>
-                                                @foreach ($today as $key=> $item)                                                    
+                                                @foreach ($yearExpense as $key=> $item)                                                    
                                                 <tr>
                                                     <td>{{ $key+1 }}</td>
                                                     
                                                     <td>{{ $item->details }}</td>
                                                     <td>{{ $item->amount }}</td>
-                                                    <td>{{ $item->month }}</td>
                                                     <td>{{ $item->year }}</td>
-                                                    <td>
-                                                        <a href="{{ route('edit.expense',$item->id) }}" class="btn btn-blue rounded-pill waves-effect waves-light">Edit</a>
-                                                    </td>
                                                 </tr>
                                                 @endforeach
                                             </tbody>

--- a/resources/views/body/sidebar.blade.php
+++ b/resources/views/body/sidebar.blade.php
@@ -178,11 +178,11 @@
                                         </li>
 
                                         <li>
-                                            <a href="{{ route('add.product') }}">Monthly Expense</a>
+                                            <a href="{{ route('month.expense') }}">Monthly Expense</a>
                                         </li>
 
                                         <li>
-                                            <a href="{{ route('add.product') }}">Yearly Expense</a>
+                                            <a href="{{ route('year.expense') }}">Yearly Expense</a>
                                         </li>
                                         
                                     </ul>

--- a/routes/web.php
+++ b/routes/web.php
@@ -117,6 +117,10 @@ Route::middleware('auth')->group(function () {
         Route::get('/add/expense', 'AddExpense')->name('add.expense');
         Route::post('/store/expense', 'StoreExpense')->name('expense.store');
         Route::get('/today/expense', 'TodayExpense')->name('today.expense');
+        Route::get('/edit/expense/{id}', 'EditExpense')->name('edit.expense');
+        Route::post('/expense/update', 'UpdateExpense')->name('expense.update');
+        Route::get('/month/expense', 'MonthExpense')->name('month.expense');
+        Route::get('/year/expense', 'YearExpense')->name('year.expense');
     });
 
 });


### PR DESCRIPTION
Implemented editing and updating expenses in `ExpenseController` and added corresponding routes. Added views for editing expenses and listing `monthly` and `yearly` expenses. Updated sidebar links to point to new `monthly` and `yearly` expense routes. Fixed edit button in `today_expense` view to use the correct route.