### PR TITLE
Add: PDF invoice download for orders

### DIFF
--- a/app/Http/Controllers/Backend/OrderController.php
+++ b/app/Http/Controllers/Backend/OrderController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Backend;
 
 use App\Http\Controllers\Controller;
+use Barryvdh\DomPDF\Facade\Pdf;
 use Illuminate\Http\Request;
 use App\Models\Product;
 use App\Models\ProductCategory;
@@ -99,5 +100,17 @@ class OrderController extends Controller
 
         $product = Product::latest()->get();
         return view('backend.stocks.all_stocks', compact('product'));
+    }
+
+    public function OrderInvoiceDownload($order_id){
+
+        $order = Order::where('id',$order_id)->first();
+        $orderItem = Orderdetails::with('product')->where('order_id',$order_id)->orderBy('id','DESC')->get();
+
+        $pdf = Pdf::loadView('backend.order.order_invoice', compact('order','orderItem'))->setPaper('a4')->setOption([
+            'tempDir' => public_path(),
+            'chroot' => public_path(),
+        ]);
+        return $pdf->download('invoice.pdf');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "barryvdh/laravel-dompdf": "^3.1",
         "hardevine/shoppingcart": "^3.4",
         "haruncpi/laravel-id-generator": "^1.1",
         "intervention/image": "^3.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,85 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8e411944f68feca6156c4c28dc7fd53a",
+    "content-hash": "e45b2796ea64138ebe2107e15935d29c",
     "packages": [
+        {
+            "name": "barryvdh/laravel-dompdf",
+            "version": "v3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/laravel-dompdf.git",
+                "reference": "8e71b99fc53bb8eb77f316c3c452dd74ab7cb25d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/laravel-dompdf/zipball/8e71b99fc53bb8eb77f316c3c452dd74ab7cb25d",
+                "reference": "8e71b99fc53bb8eb77f316c3c452dd74ab7cb25d",
+                "shasum": ""
+            },
+            "require": {
+                "dompdf/dompdf": "^3.0",
+                "illuminate/support": "^9|^10|^11|^12",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "larastan/larastan": "^2.7|^3.0",
+                "orchestra/testbench": "^7|^8|^9|^10",
+                "phpro/grumphp": "^2.5",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "PDF": "Barryvdh\\DomPDF\\Facade\\Pdf",
+                        "Pdf": "Barryvdh\\DomPDF\\Facade\\Pdf"
+                    },
+                    "providers": [
+                        "Barryvdh\\DomPDF\\ServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Barryvdh\\DomPDF\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "A DOMPDF Wrapper for Laravel",
+            "keywords": [
+                "dompdf",
+                "laravel",
+                "pdf"
+            ],
+            "support": {
+                "issues": "https://github.com/barryvdh/laravel-dompdf/issues",
+                "source": "https://github.com/barryvdh/laravel-dompdf/tree/v3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://fruitcake.nl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-13T15:07:54+00:00"
+        },
         {
             "name": "brick/math",
             "version": "0.14.0",
@@ -532,6 +609,161 @@
                 }
             ],
             "time": "2024-02-05T11:56:58+00:00"
+        },
+        {
+            "name": "dompdf/dompdf",
+            "version": "v3.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/dompdf.git",
+                "reference": "db712c90c5b9868df3600e64e68da62e78a34623"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/db712c90c5b9868df3600e64e68da62e78a34623",
+                "reference": "db712c90c5b9868df3600e64e68da62e78a34623",
+                "shasum": ""
+            },
+            "require": {
+                "dompdf/php-font-lib": "^1.0.0",
+                "dompdf/php-svg-lib": "^1.0.0",
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "masterminds/html5": "^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "ext-gd": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "mockery/mockery": "^1.3",
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.4 || ^5.4 || ^6.2 || ^7.0"
+            },
+            "suggest": {
+                "ext-gd": "Needed to process images",
+                "ext-gmagick": "Improves image processing performance",
+                "ext-imagick": "Improves image processing performance",
+                "ext-zlib": "Needed for pdf stream compression"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dompdf\\": "src/"
+                },
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "The Dompdf Community",
+                    "homepage": "https://github.com/dompdf/dompdf/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "DOMPDF is a CSS 2.1 compliant HTML to PDF converter",
+            "homepage": "https://github.com/dompdf/dompdf",
+            "support": {
+                "issues": "https://github.com/dompdf/dompdf/issues",
+                "source": "https://github.com/dompdf/dompdf/tree/v3.1.4"
+            },
+            "time": "2025-10-29T12:43:30+00:00"
+        },
+        {
+            "name": "dompdf/php-font-lib",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-font-lib.git",
+                "reference": "6137b7d4232b7f16c882c75e4ca3991dbcf6fe2d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-font-lib/zipball/6137b7d4232b7f16c882c75e4ca3991dbcf6fe2d",
+                "reference": "6137b7d4232b7f16c882c75e4ca3991dbcf6fe2d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^3 || ^4 || ^5 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FontLib\\": "src/FontLib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The FontLib Community",
+                    "homepage": "https://github.com/dompdf/php-font-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse, export and make subsets of different types of font files.",
+            "homepage": "https://github.com/dompdf/php-font-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-font-lib/issues",
+                "source": "https://github.com/dompdf/php-font-lib/tree/1.0.1"
+            },
+            "time": "2024-12-02T14:37:59+00:00"
+        },
+        {
+            "name": "dompdf/php-svg-lib",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-svg-lib.git",
+                "reference": "eb045e518185298eb6ff8d80d0d0c6b17aecd9af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-svg-lib/zipball/eb045e518185298eb6ff8d80d0d0c6b17aecd9af",
+                "reference": "eb045e518185298eb6ff8d80d0d0c6b17aecd9af",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0",
+                "sabberworm/php-css-parser": "^8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Svg\\": "src/Svg"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The SvgLib Community",
+                    "homepage": "https://github.com/dompdf/php-svg-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse and export to PDF SVG files.",
+            "homepage": "https://github.com/dompdf/php-svg-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-svg-lib/issues",
+                "source": "https://github.com/dompdf/php-svg-lib/tree/1.0.0"
+            },
+            "time": "2024-04-29T13:26:35+00:00"
         },
         {
             "name": "dragonmantank/cron-expression",
@@ -2749,6 +2981,73 @@
             "time": "2022-12-02T22:17:43+00:00"
         },
         {
+            "name": "masterminds/html5",
+            "version": "2.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Masterminds/html5-php.git",
+                "reference": "fcf91eb64359852f00d921887b219479b4f21251"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fcf91eb64359852f00d921887b219479b4f21251",
+                "reference": "fcf91eb64359852f00d921887b219479b4f21251",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Masterminds\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Butcher",
+                    "email": "technosophos@gmail.com"
+                },
+                {
+                    "name": "Matt Farina",
+                    "email": "matt@mattfarina.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                }
+            ],
+            "description": "An HTML5 parser and serializer.",
+            "homepage": "http://masterminds.github.io/html5-php",
+            "keywords": [
+                "HTML5",
+                "dom",
+                "html",
+                "parser",
+                "querypath",
+                "serializer",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/Masterminds/html5-php/issues",
+                "source": "https://github.com/Masterminds/html5-php/tree/2.10.0"
+            },
+            "time": "2025-07-25T09:04:22+00:00"
+        },
+        {
             "name": "monolog/monolog",
             "version": "3.9.0",
             "source": {
@@ -4272,6 +4571,72 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.1"
             },
             "time": "2025-09-04T20:59:21+00:00"
+        },
+        {
+            "name": "sabberworm/php-css-parser",
+            "version": "v8.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MyIntervals/PHP-CSS-Parser.git",
+                "reference": "d8e916507b88e389e26d4ab03c904a082aa66bb9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MyIntervals/PHP-CSS-Parser/zipball/d8e916507b88e389e26d4ab03c904a082aa66bb9",
+                "reference": "d8e916507b88e389e26d4ab03c904a082aa66bb9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": "^5.6.20 || ^7.0.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "5.7.27 || 6.5.14 || 7.5.20 || 8.5.41",
+                "rawr/cross-data-providers": "^2.0.0"
+            },
+            "suggest": {
+                "ext-mbstring": "for parsing UTF-8 CSS"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sabberworm\\CSS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Raphael Schweikert"
+                },
+                {
+                    "name": "Oliver Klee",
+                    "email": "github@oliverklee.de"
+                },
+                {
+                    "name": "Jake Hotson",
+                    "email": "jake.github@qzdesign.co.uk"
+                }
+            ],
+            "description": "Parser for CSS Files written in PHP",
+            "homepage": "https://www.sabberworm.com/blog/2010/6/10/php-css-parser",
+            "keywords": [
+                "css",
+                "parser",
+                "stylesheet"
+            ],
+            "support": {
+                "issues": "https://github.com/MyIntervals/PHP-CSS-Parser/issues",
+                "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v8.9.0"
+            },
+            "time": "2025-07-11T13:20:48+00:00"
         },
         {
             "name": "symfony/clock",

--- a/config/dompdf.php
+++ b/config/dompdf.php
@@ -1,0 +1,301 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Settings
+    |--------------------------------------------------------------------------
+    |
+    | Set some default values. It is possible to add all defines that can be set
+    | in dompdf_config.inc.php. You can also override the entire config file.
+    |
+    */
+    'show_warnings' => false,   // Throw an Exception on warnings from dompdf
+
+    'public_path' => null,  // Override the public path if needed
+
+    /*
+     * Dejavu Sans font is missing glyphs for converted entities, turn it off if you need to show € and £.
+     */
+    'convert_entities' => true,
+
+    'options' => [
+        /**
+         * The location of the DOMPDF font directory
+         *
+         * The location of the directory where DOMPDF will store fonts and font metrics
+         * Note: This directory must exist and be writable by the webserver process.
+         * *Please note the trailing slash.*
+         *
+         * Notes regarding fonts:
+         * Additional .afm font metrics can be added by executing load_font.php from command line.
+         *
+         * Only the original "Base 14 fonts" are present on all pdf viewers. Additional fonts must
+         * be embedded in the pdf file or the PDF may not display correctly. This can significantly
+         * increase file size unless font subsetting is enabled. Before embedding a font please
+         * review your rights under the font license.
+         *
+         * Any font specification in the source HTML is translated to the closest font available
+         * in the font directory.
+         *
+         * The pdf standard "Base 14 fonts" are:
+         * Courier, Courier-Bold, Courier-BoldOblique, Courier-Oblique,
+         * Helvetica, Helvetica-Bold, Helvetica-BoldOblique, Helvetica-Oblique,
+         * Times-Roman, Times-Bold, Times-BoldItalic, Times-Italic,
+         * Symbol, ZapfDingbats.
+         */
+        'font_dir' => storage_path('fonts'), // advised by dompdf (https://github.com/dompdf/dompdf/pull/782)
+
+        /**
+         * The location of the DOMPDF font cache directory
+         *
+         * This directory contains the cached font metrics for the fonts used by DOMPDF.
+         * This directory can be the same as DOMPDF_FONT_DIR
+         *
+         * Note: This directory must exist and be writable by the webserver process.
+         */
+        'font_cache' => storage_path('fonts'),
+
+        /**
+         * The location of a temporary directory.
+         *
+         * The directory specified must be writeable by the webserver process.
+         * The temporary directory is required to download remote images and when
+         * using the PDFLib back end.
+         */
+        'temp_dir' => sys_get_temp_dir(),
+
+        /**
+         * ==== IMPORTANT ====
+         *
+         * dompdf's "chroot": Prevents dompdf from accessing system files or other
+         * files on the webserver.  All local files opened by dompdf must be in a
+         * subdirectory of this directory.  DO NOT set it to '/' since this could
+         * allow an attacker to use dompdf to read any files on the server.  This
+         * should be an absolute path.
+         * This is only checked on command line call by dompdf.php, but not by
+         * direct class use like:
+         * $dompdf = new DOMPDF();  $dompdf->load_html($htmldata); $dompdf->render(); $pdfdata = $dompdf->output();
+         */
+        'chroot' => realpath(base_path()),
+
+        /**
+         * Protocol whitelist
+         *
+         * Protocols and PHP wrappers allowed in URIs, and the validation rules
+         * that determine if a resouce may be loaded. Full support is not guaranteed
+         * for the protocols/wrappers specified
+         * by this array.
+         *
+         * @var array
+         */
+        'allowed_protocols' => [
+            'data://' => ['rules' => []],
+            'file://' => ['rules' => []],
+            'http://' => ['rules' => []],
+            'https://' => ['rules' => []],
+        ],
+
+        /**
+         * Operational artifact (log files, temporary files) path validation
+         */
+        'artifactPathValidation' => null,
+
+        /**
+         * @var string
+         */
+        'log_output_file' => null,
+
+        /**
+         * Whether to enable font subsetting or not.
+         */
+        'enable_font_subsetting' => false,
+
+        /**
+         * The PDF rendering backend to use
+         *
+         * Valid settings are 'PDFLib', 'CPDF' (the bundled R&OS PDF class), 'GD' and
+         * 'auto'. 'auto' will look for PDFLib and use it if found, or if not it will
+         * fall back on CPDF. 'GD' renders PDFs to graphic files.
+         * {@link * Canvas_Factory} ultimately determines which rendering class to
+         * instantiate based on this setting.
+         *
+         * Both PDFLib & CPDF rendering backends provide sufficient rendering
+         * capabilities for dompdf, however additional features (e.g. object,
+         * image and font support, etc.) differ between backends.  Please see
+         * {@link PDFLib_Adapter} for more information on the PDFLib backend
+         * and {@link CPDF_Adapter} and lib/class.pdf.php for more information
+         * on CPDF. Also see the documentation for each backend at the links
+         * below.
+         *
+         * The GD rendering backend is a little different than PDFLib and
+         * CPDF. Several features of CPDF and PDFLib are not supported or do
+         * not make any sense when creating image files.  For example,
+         * multiple pages are not supported, nor are PDF 'objects'.  Have a
+         * look at {@link GD_Adapter} for more information.  GD support is
+         * experimental, so use it at your own risk.
+         *
+         * @link http://www.pdflib.com
+         * @link http://www.ros.co.nz/pdf
+         * @link http://www.php.net/image
+         */
+        'pdf_backend' => 'CPDF',
+
+        /**
+         * html target media view which should be rendered into pdf.
+         * List of types and parsing rules for future extensions:
+         * http://www.w3.org/TR/REC-html40/types.html
+         *   screen, tty, tv, projection, handheld, print, braille, aural, all
+         * Note: aural is deprecated in CSS 2.1 because it is replaced by speech in CSS 3.
+         * Note, even though the generated pdf file is intended for print output,
+         * the desired content might be different (e.g. screen or projection view of html file).
+         * Therefore allow specification of content here.
+         */
+        'default_media_type' => 'screen',
+
+        /**
+         * The default paper size.
+         *
+         * North America standard is "letter"; other countries generally "a4"
+         *
+         * @see CPDF_Adapter::PAPER_SIZES for valid sizes ('letter', 'legal', 'A4', etc.)
+         */
+        'default_paper_size' => 'a4',
+
+        /**
+         * The default paper orientation.
+         *
+         * The orientation of the page (portrait or landscape).
+         *
+         * @var string
+         */
+        'default_paper_orientation' => 'portrait',
+
+        /**
+         * The default font family
+         *
+         * Used if no suitable fonts can be found. This must exist in the font folder.
+         *
+         * @var string
+         */
+        'default_font' => 'serif',
+
+        /**
+         * Image DPI setting
+         *
+         * This setting determines the default DPI setting for images and fonts.  The
+         * DPI may be overridden for inline images by explictly setting the
+         * image's width & height style attributes (i.e. if the image's native
+         * width is 600 pixels and you specify the image's width as 72 points,
+         * the image will have a DPI of 600 in the rendered PDF.  The DPI of
+         * background images can not be overridden and is controlled entirely
+         * via this parameter.
+         *
+         * For the purposes of DOMPDF, pixels per inch (PPI) = dots per inch (DPI).
+         * If a size in html is given as px (or without unit as image size),
+         * this tells the corresponding size in pt.
+         * This adjusts the relative sizes to be similar to the rendering of the
+         * html page in a reference browser.
+         *
+         * In pdf, always 1 pt = 1/72 inch
+         *
+         * Rendering resolution of various browsers in px per inch:
+         * Windows Firefox and Internet Explorer:
+         *   SystemControl->Display properties->FontResolution: Default:96, largefonts:120, custom:?
+         * Linux Firefox:
+         *   about:config *resolution: Default:96
+         *   (xorg screen dimension in mm and Desktop font dpi settings are ignored)
+         *
+         * Take care about extra font/image zoom factor of browser.
+         *
+         * In images, <img> size in pixel attribute, img css style, are overriding
+         * the real image dimension in px for rendering.
+         *
+         * @var int
+         */
+        'dpi' => 96,
+
+        /**
+         * Enable embedded PHP
+         *
+         * If this setting is set to true then DOMPDF will automatically evaluate embedded PHP contained
+         * within <script type="text/php"> ... </script> tags.
+         *
+         * ==== IMPORTANT ==== Enabling this for documents you do not trust (e.g. arbitrary remote html pages)
+         * is a security risk.
+         * Embedded scripts are run with the same level of system access available to dompdf.
+         * Set this option to false (recommended) if you wish to process untrusted documents.
+         * This setting may increase the risk of system exploit.
+         * Do not change this settings without understanding the consequences.
+         * Additional documentation is available on the dompdf wiki at:
+         * https://github.com/dompdf/dompdf/wiki
+         *
+         * @var bool
+         */
+        'enable_php' => false,
+
+        /**
+         * Rnable inline JavaScript
+         *
+         * If this setting is set to true then DOMPDF will automatically insert JavaScript code contained
+         * within <script type="text/javascript"> ... </script> tags as written into the PDF.
+         * NOTE: This is PDF-based JavaScript to be executed by the PDF viewer,
+         * not browser-based JavaScript executed by Dompdf.
+         *
+         * @var bool
+         */
+        'enable_javascript' => true,
+
+        /**
+         * Enable remote file access
+         *
+         *  If this setting is set to true, DOMPDF will access remote sites for
+         *  images and CSS files as required.
+         *
+         *  ==== IMPORTANT ====
+         *  This can be a security risk, in particular in combination with isPhpEnabled and
+         *  allowing remote html code to be passed to $dompdf = new DOMPDF(); $dompdf->load_html(...);
+         *  This allows anonymous users to download legally doubtful internet content which on
+         *  tracing back appears to being downloaded by your server, or allows malicious php code
+         *  in remote html pages to be executed by your server with your account privileges.
+         *
+         *  This setting may increase the risk of system exploit. Do not change
+         *  this settings without understanding the consequences. Additional
+         *  documentation is available on the dompdf wiki at:
+         *  https://github.com/dompdf/dompdf/wiki
+         *
+         * @var bool
+         */
+        'enable_remote' => false,
+
+        /**
+         * List of allowed remote hosts
+         *
+         * Each value of the array must be a valid hostname.
+         *
+         * This will be used to filter which resources can be loaded in combination with
+         * isRemoteEnabled. If enable_remote is FALSE, then this will have no effect.
+         *
+         * Leave to NULL to allow any remote host.
+         *
+         * @var array|null
+         */
+        'allowed_remote_hosts' => null,
+
+        /**
+         * A ratio applied to the fonts height to be more like browsers' line height
+         */
+        'font_height_ratio' => 1.1,
+
+        /**
+         * Use the HTML5 Lib parser
+         *
+         * @deprecated This feature is now always on in dompdf 2.x
+         *
+         * @var bool
+         */
+        'enable_html5_parser' => true,
+    ],
+
+];

--- a/resources/views/backend/order/complete_order.blade.php
+++ b/resources/views/backend/order/complete_order.blade.php
@@ -58,7 +58,7 @@
                                                     <td>{{ $item->pay }}</td>
                                                     <td><span class="badge bg-success">{{ $item->order_status }}</span></td>
                                                     <td>
-                                                        <a href="{{ route('order.details',$item->id) }}" class="btn btn-blue rounded-pill waves-effect waves-light">PDF Invoice</a>
+                                                        <a href="{{ url('order/invoice-download',$item->id) }}" class="btn btn-blue rounded-pill waves-effect waves-light">PDF Invoice</a>
                                                     </td>
                                                 </tr>
                                                 @endforeach

--- a/resources/views/backend/order/order_invoice.blade.php
+++ b/resources/views/backend/order/order_invoice.blade.php
@@ -1,0 +1,148 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<title>Invoice</title>
+
+<style type="text/css">
+    * {
+        font-family: Verdana, Arial, sans-serif;
+    }
+    table{
+        font-size: x-small;
+    }
+    tfoot tr td{
+        font-weight: bold;
+        font-size: x-small;
+    }
+    .gray {
+        background-color: lightgray
+    }
+    .font{
+      font-size: 15px;
+    }
+    .authority {
+        /*text-align: center;*/
+        float: right
+    }
+    .authority h5 {
+        margin-top: -10px;
+        color: #566676;
+        /*text-align: center;*/
+        margin-left: 35px;
+    }
+    .thanks p {
+        color: #566676;
+        font-size: 16px;
+        font-weight: normal;
+        font-family: serif;
+        margin-top: 20px;
+    }
+</style>
+
+</head>
+<body>
+
+  <table width="100%" style="background: #F7F7F7; padding:0 20px 0 20px;">
+    <tr>
+        <td valign="top">
+          <!-- {{-- <img src="" alt="" width="150"/> --}} -->
+          <h2 style="color: #566676; font-size: 26px;"><strong>EasyShop</strong></h2>
+        </td>
+        <td align="right">
+            <pre class="font" >
+               EasyShop Head Office
+               Email:support@easylearningbd.com <br>
+               Mob: 1245454545 <br>
+               Dhaka 1207,Dhanmondi:#4 <br>
+              
+            </pre>
+        </td>
+    </tr>
+
+  </table>
+
+
+  <table width="100%" style="background:white; padding:2px;"></table>
+
+  <table width="100%" style="background: #F7F7F7; padding:0 5 0 5px;" class="font">
+    <tr>
+        <td>
+          <p class="font" style="margin-left: 20px;">
+           <strong>Customer Name:</strong> {{ $order->customer->name }}  <br>
+           <strong>Customer Email:</strong> {{ $order->customer->email }}  <br>
+           <strong>Customer Phone:</strong>  {{ $order->customer->phone }} <br>
+          
+           <strong>Address: {{ $order->customer->address }} </strong>  
+            <strong>Shop Name: {{ $order->customer->shopname }} </strong>  
+            
+         </p>
+        </td>
+        <td>
+          <p class="font">
+            <h3><span style="color: #566676;">Invoice:</span> #{{ $order->invoice_no }}  </h3>
+            Order Date:  {{ $order->order_date }} <br>
+            Order Status: {{ $order->order_status }}  <br>
+            Payment Status: {{ $order->payment_status }}  <br>
+            Total Pay : {{ $order->pay }}  <br>
+            Total Due : {{ $order->due }}  </span>
+
+         </p>
+        </td>
+    </tr>
+  </table>
+  <br/>
+<h3>Products</h3>
+
+
+  <table width="100%">
+    <thead style="background-color: #566676; color:#FFFFFF;">
+      <tr class="font">
+         <th>Image </th>
+        <th>Product Name</th>
+        <th>Product Code</th>
+        <th>Quantity</th>
+        <th>Price</th>
+        <th>Total(+Vat)</th>
+      </tr>
+    </thead>
+    <tbody>
+
+     @foreach($orderItem as $item)
+      <tr class="font">
+        <td align="center">
+            <img src="{{ public_path($item->product->product_image) }}" height="50px;" width="50px;" alt="">
+        </td>
+        <td align="center"> {{ $item->product->product_name }} </td>
+        
+        <td align="center"> {{ $item->product->product_code }} </td>
+        <td align="center"> {{ $item->quantity }} </td>
+
+         
+        
+        <td align="center">${{ $item->product->selling_price }} </td>
+         <td align="center">${{ $item->total }} </td>
+      </tr>
+      @endforeach
+    </tbody>
+  </table>
+  <br>
+  <table width="100%" style=" padding:0 10px 0 10px;">
+    <tr>
+        <td align="right" >
+            <h2><span style="color: #566676;">Subtotal:</span>${{ $order->total }} </h2>
+            <h2><span style="color: #566676;">Total:</span> ${{ $order->total }} </h2>
+            {{-- <h2><span style="color: green;">Full Payment PAID</h2> --}}
+        </td>
+    </tr>
+  </table>
+  <div class="thanks mt-3">
+    <p>Thanks For Buying Products..!!</p>
+  </div>
+  <div class="authority float-right mt-5">
+      <p>-----------------------------------</p>
+      <h5>Authority Signature:</h5>
+    </div>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -141,6 +141,7 @@ Route::middleware('auth')->group(function () {
         Route::get('/order/details/{order_id}', 'OrderDetails')->name('order.details');
         Route::post('/order/status/update', 'OrderStatusUpdate')->name('order.status.update');
         Route::get('/manage/stocks', 'ManageStocks')->name('manage.stocks');
+        Route::get('/order/invoice-download/{order_id}', 'OrderInvoiceDownload');
     });
 
 });


### PR DESCRIPTION
Integrated `barryvdh/laravel-dompdf` to enable `PDF invoice generation` and download for `orders`. Added `OrderInvoiceDownload` method in `OrderController`, created invoice view, updated routes, and modified the order list to link to the new download endpoint.