### PR TITLE
Add permission-based access control to routes and views

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,6 +12,11 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware): void {
         //
+        $middleware->alias([
+            'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,
+            'permission' => \Spatie\Permission\Middleware\PermissionMiddleware::class,
+            'role_or_permission' => \Spatie\Permission\Middleware\RoleOrPermissionMiddleware::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/resources/views/backend/admin/all_admin.blade.php
+++ b/resources/views/backend/admin/all_admin.blade.php
@@ -13,9 +13,11 @@
                             <div class="col-12">
                                 <div class="page-title-box">
                                     <div class="page-title-right">
+                                        @if (Auth::user()->can('admin.add'))
                                         <ol class="breadcrumb m-0">
                                             <a href="{{ route('add.admin') }}" class="btn btn-primary rounded-pill waves-effect waves-light">Add Admin</a>
                                         </ol>
+                                        @endif
                                     </div>
                                     <h4 class="page-title">All Admin <span class="btn btn-danger">{{ count($alladminuser) }}</span> </h4>
                                 </div>
@@ -58,8 +60,12 @@
                                                         @endforeach
                                                     </td>
                                                     <td>
+                                                        @if (Auth::user()->can('admin.edit'))
                                                         <a href="{{ route('edit.admin',$item->id) }}" class="btn btn-blue rounded-pill waves-effect waves-light">Edit</a>
+                                                        @endif
+                                                        @if (Auth::user()->can('admin.delete'))
                                                         <a href="{{ route('delete.admin',$item->id) }}" class="btn btn-danger rounded-pill waves-effect waves-light" id="delete">Delete</a>
+                                                        @endif
                                                     </td>
                                                 </tr>
                                                 @endforeach

--- a/resources/views/backend/attendance/view_employee_attendance.blade.php
+++ b/resources/views/backend/attendance/view_employee_attendance.blade.php
@@ -13,9 +13,11 @@
                             <div class="col-12">
                                 <div class="page-title-box">
                                     <div class="page-title-right">
+                                        @if (Auth::user()->can('attendance.add'))
                                         <ol class="breadcrumb m-0">
                                             <a href="{{ route('add.employee.attendance') }}" class="btn btn-primary rounded-pill waves-effect waves-light">Add Employee Attendance</a>
                                         </ol>
+                                        @endif
                                     </div>
                                     <h4 class="page-title">All Employee Attendance</h4>
                                 </div>
@@ -46,7 +48,9 @@
                                                     <td>{{ $key+1 }}</td>
                                                     <td>{{ date('Y-m-d', strtotime($item->date)) }}</td>
                                                     <td>
+                                                        @if (Auth::user()->can('attendance.edit'))
                                                         <a href="{{ route('employee.attendance.edit', $item->date) }}" class="btn btn-blue rounded-pill waves-effect waves-light">Edit</a>
+                                                        @endif
                                                         <a href="{{ route('employee.attendance.view', $item->date) }}" class="btn btn-danger rounded-pill waves-effect waves-light">View</a>
                                                     </td>
                                                 </tr>

--- a/resources/views/backend/customer/all_customer.blade.php
+++ b/resources/views/backend/customer/all_customer.blade.php
@@ -13,9 +13,11 @@
                             <div class="col-12">
                                 <div class="page-title-box">
                                     <div class="page-title-right">
+                                        @if (Auth::user()->can('customer.add'))
                                         <ol class="breadcrumb m-0">
                                             <a href="{{ route('add.customer') }}" class="btn btn-primary rounded-pill waves-effect waves-light">Add Customer</a>
                                         </ol>
+                                        @endif
                                     </div>
                                     <h4 class="page-title">All Customer</h4>
                                 </div>
@@ -54,8 +56,12 @@
                                                     <td>{{ $item->phone }}</td>
                                                     <td>{{ $item->shopname }}</td>
                                                     <td>
+                                                        @if (Auth::user()->can('customer.edit'))
                                                         <a href="{{ route('edit.customer',$item->id) }}" class="btn btn-blue rounded-pill waves-effect waves-light">Edit</a>
+                                                        @endif
+                                                        @if (Auth::user()->can('customer.delete'))
                                                         <a href="{{ route('delete.customer',$item->id) }}" class="btn btn-danger rounded-pill waves-effect waves-light" id="delete">Delete</a>
+                                                        @endif
                                                     </td>
                                                 </tr>
                                                 @endforeach

--- a/resources/views/backend/employee/all_employee.blade.php
+++ b/resources/views/backend/employee/all_employee.blade.php
@@ -13,9 +13,11 @@
                             <div class="col-12">
                                 <div class="page-title-box">
                                     <div class="page-title-right">
+                                        @if (Auth::user()->can('employee.add'))
                                         <ol class="breadcrumb m-0">
                                             <a href="{{ route('add.employee') }}" class="btn btn-primary rounded-pill waves-effect waves-light">Add Employee</a>
                                         </ol>
+                                        @endif
                                     </div>
                                     <h4 class="page-title">All Employee</h4>
                                 </div>
@@ -54,8 +56,12 @@
                                                     <td>{{ $item->phone }}</td>
                                                     <td>{{ $item->salary }}</td>
                                                     <td>
+                                                        @if (Auth::user()->can('employee.edit'))
                                                         <a href="{{ route('edit.employee',$item->id) }}" class="btn btn-blue rounded-pill waves-effect waves-light">Edit</a>
+                                                        @endif
+                                                        @if (Auth::user()->can('employee.delete'))
                                                         <a href="{{ route('delete.employee',$item->id) }}" class="btn btn-danger rounded-pill waves-effect waves-light" id="delete">Delete</a>
+                                                        @endif
                                                     </td>
                                                 </tr>
                                                 @endforeach

--- a/resources/views/backend/expense/month_expense.blade.php
+++ b/resources/views/backend/expense/month_expense.blade.php
@@ -13,9 +13,11 @@
                             <div class="col-12">
                                 <div class="page-title-box">
                                     <div class="page-title-right">
+                                        @if (Auth::user()->can('expense.add'))
                                         <ol class="breadcrumb m-0">
                                             <a href="{{ route('add.expense') }}" class="btn btn-primary rounded-pill waves-effect waves-light">Add Expense</a>
                                         </ol>
+                                        @endif
                                     </div>
                                     <h4 class="page-title">Month Expense</h4>
                                 </div>

--- a/resources/views/backend/expense/today_expense.blade.php
+++ b/resources/views/backend/expense/today_expense.blade.php
@@ -13,9 +13,11 @@
                             <div class="col-12">
                                 <div class="page-title-box">
                                     <div class="page-title-right">
+                                        @if (Auth::user()->can('expense.add'))
                                         <ol class="breadcrumb m-0">
                                             <a href="{{ route('add.expense') }}" class="btn btn-primary rounded-pill waves-effect waves-light">Add Expense</a>
                                         </ol>
+                                        @endif
                                     </div>
                                     <h4 class="page-title">Today's Expense</h4>
                                 </div>
@@ -63,7 +65,9 @@
                                                     <td>{{ $item->month }}</td>
                                                     <td>{{ $item->year }}</td>
                                                     <td>
+                                                        @if (Auth::user()->can('expense.edit'))
                                                         <a href="{{ route('edit.expense',$item->id) }}" class="btn btn-blue rounded-pill waves-effect waves-light">Edit</a>
+                                                        @endif
                                                     </td>
                                                 </tr>
                                                 @endforeach

--- a/resources/views/backend/expense/year_expense.blade.php
+++ b/resources/views/backend/expense/year_expense.blade.php
@@ -13,9 +13,11 @@
                             <div class="col-12">
                                 <div class="page-title-box">
                                     <div class="page-title-right">
+                                        @if (Auth::user()->can('expense.add'))
                                         <ol class="breadcrumb m-0">
                                             <a href="{{ route('add.expense') }}" class="btn btn-primary rounded-pill waves-effect waves-light">Add Expense</a>
                                         </ol>
+                                        @endif
                                     </div>
                                     <h4 class="page-title">Year Expense</h4>
                                 </div>
@@ -46,6 +48,7 @@
                                                     <th>Sl</th>
                                                     <th>Details</th>
                                                     <th>Amount</th>
+                                                    <th>Month</th>
                                                     <th>Year</th>
                                                 </tr>
                                             </thead>
@@ -58,6 +61,7 @@
                                                     
                                                     <td>{{ $item->details }}</td>
                                                     <td>{{ $item->amount }}</td>
+                                                    <td>{{ $item->month }}</td>
                                                     <td>{{ $item->year }}</td>
                                                 </tr>
                                                 @endforeach

--- a/resources/views/backend/order/complete_order.blade.php
+++ b/resources/views/backend/order/complete_order.blade.php
@@ -58,7 +58,9 @@
                                                     <td>{{ $item->pay }}</td>
                                                     <td><span class="badge bg-success">{{ $item->order_status }}</span></td>
                                                     <td>
+                                                        @if (Auth::user()->can('orders.pdf.download'))
                                                         <a href="{{ url('order/invoice-download',$item->id) }}" class="btn btn-blue rounded-pill waves-effect waves-light">PDF Invoice</a>
+                                                        @endif
                                                     </td>
                                                 </tr>
                                                 @endforeach

--- a/resources/views/backend/order/pending_order.blade.php
+++ b/resources/views/backend/order/pending_order.blade.php
@@ -58,7 +58,9 @@
                                                     <td>{{ $item->pay }}</td>
                                                     <td><span class="badge bg-danger">{{ $item->order_status }}</span></td>
                                                     <td>
+                                                        @if (Auth::user()->can('orders.detail'))
                                                         <a href="{{ route('order.details',$item->id) }}" class="btn btn-blue rounded-pill waves-effect waves-light">Order Details</a>
+                                                        @endif
                                                     </td>
                                                 </tr>
                                                 @endforeach

--- a/resources/views/backend/pages/permission/add_permission.blade.php
+++ b/resources/views/backend/pages/permission/add_permission.blade.php
@@ -67,6 +67,7 @@
                                                                     <option value="orders">Orders</option>
                                                                     <option value="stock">Stock</option>
                                                                     <option value="roles">Roles</option>
+                                                                    <option value="admin">Admin</option>
                                                                 </select>
                                                             </div>
                                                         </div>

--- a/resources/views/backend/pages/permission/all_permission.blade.php
+++ b/resources/views/backend/pages/permission/all_permission.blade.php
@@ -14,7 +14,9 @@
                                 <div class="page-title-box">
                                     <div class="page-title-right">
                                         <ol class="breadcrumb m-0">
+                                            @if (Auth::user()->can('roles.permission.add'))
                                             <a href="{{ route('add.permission') }}" class="btn btn-primary rounded-pill waves-effect waves-light">Add Permission</a>
+                                            @endif
                                         </ol>
                                     </div>
                                     <h4 class="page-title">All Permission</h4>
@@ -48,8 +50,12 @@
                                                     <td>{{ $item->name }}</td>
                                                     <td>{{ $item->group_name }}</td>
                                                     <td>
+                                                        @if (Auth::user()->can('roles.permission.edit'))
                                                         <a href="{{ route('edit.permission',$item->id) }}" class="btn btn-blue rounded-pill waves-effect waves-light">Edit</a>
+                                                        @endif
+                                                        @if (Auth::user()->can('roles.permission.delete'))
                                                         <a href="{{ route('delete.permission',$item->id) }}" class="btn btn-danger rounded-pill waves-effect waves-light" id="delete">Delete</a>
+                                                        @endif
                                                     </td>
                                                 </tr>
                                                 @endforeach

--- a/resources/views/backend/pages/roles/all_roles.blade.php
+++ b/resources/views/backend/pages/roles/all_roles.blade.php
@@ -14,7 +14,9 @@
                                 <div class="page-title-box">
                                     <div class="page-title-right">
                                         <ol class="breadcrumb m-0">
+                                            @if (Auth::user()->can('roles.all.add'))
                                             <a href="{{ route('add.role') }}" class="btn btn-primary rounded-pill waves-effect waves-light">Add Role</a>
+                                            @endif
                                         </ol>
                                     </div>
                                     <h4 class="page-title">All Roles</h4>
@@ -46,8 +48,12 @@
                                                     <td>{{ $key+1 }}</td>
                                                     <td>{{ $item->name }}</td>
                                                     <td>
+                                                        @if (Auth::user()->can('roles.all.edit'))
                                                         <a href="{{ route('edit.role',$item->id) }}" class="btn btn-blue rounded-pill waves-effect waves-light">Edit</a>
+                                                        @endif
+                                                        @if (Auth::user()->can('roles.all.delete'))
                                                         <a href="{{ route('delete.role',$item->id) }}" class="btn btn-danger rounded-pill waves-effect waves-light" id="delete">Delete</a>
+                                                        @endif
                                                     </td>
                                                 </tr>
                                                 @endforeach

--- a/resources/views/backend/pages/roles/all_roles_permission.blade.php
+++ b/resources/views/backend/pages/roles/all_roles_permission.blade.php
@@ -14,7 +14,9 @@
                                 <div class="page-title-box">
                                     <div class="page-title-right">
                                         <ol class="breadcrumb m-0">
+                                            @if (Auth::user()->can('roles.in.permission.add'))
                                             <a href="{{ route('add.roles.permission') }}" class="btn btn-primary rounded-pill waves-effect waves-light">Add Roles in Permission</a>
+                                            @endif
                                         </ol>
                                     </div>
                                     <h4 class="page-title">All Roles in Permission</h4>
@@ -54,8 +56,12 @@
 
                                                     </td>
                                                     <td width="18%">
+                                                        @if (Auth::user()->can('roles.in.permission.edit'))
                                                         <a href="{{ route('edit.role.permission',$item->id) }}" class="btn btn-blue rounded-pill waves-effect waves-light">Edit</a>
+                                                        @endif
+                                                        @if (Auth::user()->can('roles.in.permission.delete'))
                                                         <a href="{{ route('delete.role.permission',$item->id) }}" class="btn btn-danger rounded-pill waves-effect waves-light" id="delete">Delete</a>
+                                                        @endif
                                                     </td>
                                                 </tr>
                                                 @endforeach

--- a/resources/views/backend/product/all_product.blade.php
+++ b/resources/views/backend/product/all_product.blade.php
@@ -14,11 +14,17 @@
                                 <div class="page-title-box">
                                     <div class="page-title-right">
                                         <ol class="breadcrumb m-0">
+                                            @if (Auth::user()->can('product.export'))
                                             <a href="{{ route('export') }}" class="btn btn-danger rounded-pill waves-effect waves-light">Export Product</a>
+                                            @endif
                                             &nbsp; &nbsp; &nbsp;
+                                            @if (Auth::user()->can('product.import'))
                                             <a href="{{ route('import.product') }}" class="btn btn-info rounded-pill waves-effect waves-light">Import Product</a>
+                                            @endif
                                             &nbsp; &nbsp; &nbsp;
+                                            @if (Auth::user()->can('product.add'))
                                             <a href="{{ route('add.product') }}" class="btn btn-primary rounded-pill waves-effect waves-light">Add Product</a>
+                                            @endif
                                         </ol>
                                     </div>
                                     <h4 class="page-title">All Products</h4>
@@ -60,9 +66,15 @@
                                                     <td>{{ $item->product_code }}</td>
                                                     <td>{{ $item->selling_price }}</td>
                                                     <td>
+                                                        @if (Auth::user()->can('product.edit'))
                                                         <a href="{{ route('edit.product',$item->id) }}" class="btn btn-blue rounded-pill waves-effect waves-light">Edit</a>
+                                                        @endif
+                                                        @if (Auth::user()->can('product.barcode'))
                                                         <a href="{{ route('barcode.product',$item->id) }}" class="btn btn-info rounded-pill waves-effect waves-light">Barcode</a>
+                                                        @endif
+                                                        @if (Auth::user()->can('product.delete'))
                                                         <a href="{{ route('delete.product',$item->id) }}" class="btn btn-danger rounded-pill waves-effect waves-light" id="delete">Delete</a>
+                                                        @endif
                                                     </td>
                                                 </tr>
                                                 @endforeach

--- a/resources/views/backend/product/import_product.blade.php
+++ b/resources/views/backend/product/import_product.blade.php
@@ -13,9 +13,11 @@
                             <div class="col-12">
                                 <div class="page-title-box">
                                     <div class="page-title-right">
+                                        @if (Auth::user()->can('product.export'))
                                         <ol class="breadcrumb m-0">
                                             <a href="{{ route('export') }}" class="btn btn-primary rounded-pill waves-effect waves-light">Download Xlsx</a>
                                         </ol>
+                                        @endif
                                     </div>
                                     <h4 class="page-title">Import Product</h4>
                                 </div>

--- a/resources/views/backend/product_category/all_product_category.blade.php
+++ b/resources/views/backend/product_category/all_product_category.blade.php
@@ -13,9 +13,11 @@
                             <div class="col-12">
                                 <div class="page-title-box">
                                     <div class="page-title-right">
+                                        @if (Auth::user()->can('category.add'))
                                         <ol class="breadcrumb m-0">
                                             <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#signup-modal">Add Product Category</button>
                                         </ol>
+                                        @endif
                                     </div>
                                     <h4 class="page-title">All Product Categories</h4>
                                 </div>
@@ -46,8 +48,12 @@
                                                     <td>{{ $key+1 }}</td>
                                                     <td>{{ $item->category_name }}</td>
                                                     <td>
+                                                        @if (Auth::user()->can('category.edit'))
                                                         <a href="{{ route('edit.product.category',$item->id) }}" class="btn btn-blue rounded-pill waves-effect waves-light">Edit</a>
+                                                        @endif
+                                                        @if (Auth::user()->can('category.delete'))
                                                         <a href="{{ route('delete.product.category',$item->id) }}" class="btn btn-danger rounded-pill waves-effect waves-light" id="delete">Delete</a>
+                                                        @endif
                                                     </td>
                                                 </tr>
                                                 @endforeach

--- a/resources/views/backend/salary/all_advance_salary.blade.php
+++ b/resources/views/backend/salary/all_advance_salary.blade.php
@@ -13,9 +13,11 @@
                             <div class="col-12">
                                 <div class="page-title-box">
                                     <div class="page-title-right">
+                                        @if (Auth::user()->can('salary.add'))
                                         <ol class="breadcrumb m-0">
                                             <a href="{{ route('add.advance.salary') }}" class="btn btn-primary rounded-pill waves-effect waves-light">Add Advance Salary</a>
                                         </ol>
+                                        @endif
                                     </div>
                                     <h4 class="page-title">All Advance Salary</h4>  
                                 </div>
@@ -62,8 +64,12 @@
                                                         
                                                     </td>
                                                     <td>
+                                                        @if (Auth::user()->can('salary.edit'))
                                                         <a href="{{ route('edit.advance.salary',$item->id) }}" class="btn btn-blue rounded-pill waves-effect waves-light">Edit</a>
+                                                        @endif
+                                                        @if (Auth::user()->can('salary.delete'))
                                                         <a href="{{ route('delete.advance.salary',$item->id) }}" class="btn btn-danger rounded-pill waves-effect waves-light" id="delete">Delete</a>
+                                                        @endif
                                                     </td>
                                                 </tr>
                                                 @endforeach

--- a/resources/views/backend/salary/month_salary.blade.php
+++ b/resources/views/backend/salary/month_salary.blade.php
@@ -13,9 +13,11 @@
                             <div class="col-12">
                                 <div class="page-title-box">
                                     <div class="page-title-right">
+                                        @if (Auth::user()->can('salary.add'))
                                         <ol class="breadcrumb m-0">
                                             <a href="{{ route('add.advance.salary') }}" class="btn btn-primary rounded-pill waves-effect waves-light">Add Advance Salary</a>
                                         </ol>
+                                        @endif
                                     </div>
                                     <h4 class="page-title">Last Month Salary</h4>  
                                 </div>
@@ -54,7 +56,9 @@
                                                     <td>{{ $item['employee']['salary'] }}</td>
                                                     <td><span class="badge bg-blue">Fully Paid</span></td>
                                                     <td>
+                                                        @if (Auth::user()->can('salary.edit'))
                                                         <a href="{{ route('edit.advance.salary',$item->id) }}" class="btn btn-blue rounded-pill waves-effect waves-light">History</a>
+                                                        @endif
                                                     </td>
                                                 </tr>
                                                 @endforeach

--- a/resources/views/backend/salary/pay_salary.blade.php
+++ b/resources/views/backend/salary/pay_salary.blade.php
@@ -13,9 +13,11 @@
                             <div class="col-12">
                                 <div class="page-title-box">
                                     <div class="page-title-right">
+                                        @if (Auth::user()->can('salary.add'))
                                         <ol class="breadcrumb m-0">
                                             <a href="{{ route('add.advance.salary') }}" class="btn btn-primary rounded-pill waves-effect waves-light">Add Advance Salary</a>
                                         </ol>
+                                        @endif
                                     </div>
                                     <h4 class="page-title">All Pay Salary</h4>  
                                 </div>
@@ -71,7 +73,9 @@
 
                                                     </td>
                                                     <td>
+                                                        @if (Auth::user()->can('salary.pay.now'))
                                                         <a href="{{ route('pay.salary.now',$item->id) }}" class="btn btn-blue rounded-pill waves-effect waves-light">Pay Now</a>
+                                                        @endif
                                                     </td>
                                                 </tr>
                                                 @endforeach

--- a/resources/views/backend/stocks/all_stocks.blade.php
+++ b/resources/views/backend/stocks/all_stocks.blade.php
@@ -14,11 +14,17 @@
                                 <div class="page-title-box">
                                     <div class="page-title-right">
                                         <ol class="breadcrumb m-0">
+                                            @if (Auth::user()->can('product.export'))
                                             <a href="{{ route('export') }}" class="btn btn-danger rounded-pill waves-effect waves-light">Export Product</a>
+                                            @endif
                                             &nbsp; &nbsp; &nbsp;
+                                            @if (Auth::user()->can('product.import'))
                                             <a href="{{ route('import.product') }}" class="btn btn-info rounded-pill waves-effect waves-light">Import Product</a>
+                                            @endif
                                             &nbsp; &nbsp; &nbsp;
+                                            @if (Auth::user()->can('product.add'))
                                             <a href="{{ route('add.product') }}" class="btn btn-primary rounded-pill waves-effect waves-light">Add Product</a>
+                                            @endif
                                         </ol>
                                     </div>
                                     <h4 class="page-title">All Products</h4>

--- a/resources/views/backend/supplier/all_supplier.blade.php
+++ b/resources/views/backend/supplier/all_supplier.blade.php
@@ -13,9 +13,11 @@
                             <div class="col-12">
                                 <div class="page-title-box">
                                     <div class="page-title-right">
+                                        @if (Auth::user()->can('supplier.add'))
                                         <ol class="breadcrumb m-0">
                                             <a href="{{ route('add.supplier') }}" class="btn btn-primary rounded-pill waves-effect waves-light">Add Supplier</a>
                                         </ol>
+                                        @endif
                                     </div>
                                     <h4 class="page-title">All Supplier</h4>
                                 </div>
@@ -54,8 +56,12 @@
                                                     <td>{{ $item->phone }}</td>
                                                     <td>{{ $item->type }}</td>
                                                     <td>
+                                                        @if (Auth::user()->can('supplier.edit'))
                                                         <a href="{{ route('edit.supplier',$item->id) }}" class="btn btn-blue rounded-pill waves-effect waves-light" title="Edit"> <i class="fa fa-pencil" aria-hidden="true"></i></a>
+                                                        @endif
+                                                        @if (Auth::user()->can('supplier.delete'))
                                                         <a href="{{ route('delete.supplier',$item->id) }}" class="btn btn-danger rounded-pill waves-effect waves-light" id="delete" title="Delete"><i class="fa fa-trash" aria-hidden="true"></i></a>
+                                                        @endif
                                                         <a href="{{ route('details.supplier',$item->id) }}" class="btn btn-info rounded-pill waves-effect waves-light" title=" View Supplier Detials"><i class="fa fa-eye" aria-hidden="true"></i></a>
                                                     </td>
                                                 </tr>

--- a/resources/views/body/sidebar.blade.php
+++ b/resources/views/body/sidebar.blade.php
@@ -19,6 +19,7 @@
                                 </a>
                             </li>
 
+                            @if (Auth::user()->can('pos.menu'))
                             <li>
                                 <a href="{{ route('pos') }}">
                                     <span class="badge bg-pink float-end">New</span>
@@ -26,15 +27,15 @@
                                     <span> POS </span>
                                 </a>
                             </li>
-                
+                            @endif
                             
 
-                            <li class="menu-title mt-2">Apps</li>
+                            <li class="menu-title mt-2">Menu</li>
 
                             
 
                             
-
+                            @if (Auth::user()->can('employee.menu'))
                             <li>
                                 <a href="#sidebarEmployees" data-bs-toggle="collapse">
                                     <i class="mdi mdi-account-tie"></i>
@@ -43,16 +44,22 @@
                                 </a>
                                 <div class="collapse" id="sidebarEmployees">
                                     <ul class="nav-second-level">
+                                        @if (Auth::user()->can('employee.all'))
                                         <li>
                                             <a href="{{ route('all.employee') }}">All Employees</a>
                                         </li>
+                                        @endif
+                                        @if (Auth::user()->can('employee.add'))
                                         <li>
                                             <a href="{{ route('add.employee') }}">Add Employee</a>
                                         </li>
+                                        @endif
                                     </ul>
                                 </div>
                             </li>
+                            @endif
 
+                            @if (Auth::user()->can('customer.menu'))
                             <li>
                                 <a href="#sidebarCustomers" data-bs-toggle="collapse">
                                     <i class="mdi mdi-account-multiple-outline"></i>
@@ -61,16 +68,22 @@
                                 </a>
                                 <div class="collapse" id="sidebarCustomers">
                                     <ul class="nav-second-level">
+                                        @if (Auth::user()->can('customer.all'))
                                         <li>
                                             <a href="{{ route('all.customer') }}">All Customers</a>
                                         </li>
+                                        @endif
+                                        @if (Auth::user()->can('customer.add'))
                                         <li>
                                             <a href="{{ route('add.customer') }}">Add Customer</a>
                                         </li>
+                                        @endif
                                     </ul>
                                 </div>
                             </li>
+                            @endif
 
+                            @if (Auth::user()->can('supplier.menu'))
                             <li>
                                 <a href="#sidebarSuppliers" data-bs-toggle="collapse">
                                     <i class="mdi mdi-truck-delivery-outline"></i>
@@ -79,16 +92,22 @@
                                 </a>
                                 <div class="collapse" id="sidebarSuppliers">
                                     <ul class="nav-second-level">
+                                        @if (Auth::user()->can('supplier.all'))
                                         <li>
                                             <a href="{{ route('all.supplier') }}">All Suppliers</a>
                                         </li>
+                                        @endif
+                                        @if (Auth::user()->can('supplier.add'))
                                         <li>
                                             <a href="{{ route('add.supplier') }}">Add Supplier</a>
                                         </li>
+                                        @endif
                                     </ul>
                                 </div>
                             </li>
+                            @endif
 
+                            @if (Auth::user()->can('salary.menu'))
                             <li>
                                 <a href="#sidebarSalary" data-bs-toggle="collapse">
                                     <i class=" mdi mdi-cash-usd-outline"></i>
@@ -97,22 +116,32 @@
                                 </a>
                                 <div class="collapse" id="sidebarSalary">
                                     <ul class="nav-second-level">
+                                        @if (Auth::user()->can('salary.add'))
                                         <li>
                                             <a href="{{ route('add.advance.salary') }}">Add Advance Salary</a>
                                         </li>
+                                        @endif
+                                        @if (Auth::user()->can('salary.all'))
                                         <li>
                                             <a href="{{ route('all.advance.salary') }}">All Advance Salary</a>
                                         </li>
+                                        @endif
+                                        @if (Auth::user()->can('salary.pay'))
                                         <li>
                                             <a href="{{ route('pay.salary') }}">Pay Salary</a>
                                         </li>
+                                        @endif
+                                        @if (Auth::user()->can('salary.month'))
                                         <li>
                                             <a href="{{ route('month.salary') }}">Last Month Salary</a>
                                         </li>
+                                        @endif
                                     </ul>
                                 </div>
                             </li>
+                            @endif
 
+                            @if (Auth::user()->can('attendance.menu'))
                             <li>
                                 <a href="#attendance" data-bs-toggle="collapse">
                                     <i class=" mdi mdi-calendar-check"></i>
@@ -121,14 +150,17 @@
                                 </a>
                                 <div class="collapse" id="attendance">
                                     <ul class="nav-second-level">
+                                        @if (Auth::user()->can('attendance.list'))
                                         <li>
                                             <a href="{{ route('employee.attendance.list') }}">Employee Attendance List</a>
                                         </li>
-                                        
+                                        @endif
                                     </ul>
                                 </div>
                             </li>
+                            @endif
 
+                            @if (Auth::user()->can('category.menu'))
                             <li>
                                 <a href="#prodcutCategory" data-bs-toggle="collapse">
                                     <i class=" mdi mdi-folder-heart"></i>
@@ -137,14 +169,17 @@
                                 </a>
                                 <div class="collapse" id="prodcutCategory">
                                     <ul class="nav-second-level">
+                                        @if (Auth::user()->can('category.all'))
                                         <li>
                                             <a href="{{ route('all.product.category') }}">All Product Category</a>
                                         </li>
-                                        
+                                        @endif
                                     </ul>
                                 </div>
                             </li>
+                            @endif
 
+                            @if (Auth::user()->can('product.menu'))
                             <li>
                                 <a href="#manageProducts" data-bs-toggle="collapse">
                                     <i class=" mdi mdi-cart-outline"></i>
@@ -153,22 +188,27 @@
                                 </a>
                                 <div class="collapse" id="manageProducts">
                                     <ul class="nav-second-level">
+                                        @if (Auth::user()->can('product.all'))
                                         <li>
                                             <a href="{{ route('all.product') }}">All Products</a>
                                         </li>
-
+                                        @endif
+                                        @if (Auth::user()->can('product.add'))
                                         <li>
                                             <a href="{{ route('add.product') }}">Add Products</a>
                                         </li>
-
+                                        @endif
+                                        @if (Auth::user()->can('product.import'))
                                         <li>
                                             <a href="{{ route('import.product') }}">Import Products</a>
                                         </li>
-                                        
+                                        @endif
                                     </ul>
                                 </div>
                             </li>
+                            @endif
 
+                            @if (Auth::user()->can('expense.menu'))
                             <li>
                                 <a href="#manageExpense" data-bs-toggle="collapse">
                                     <i class=" mdi mdi-cash"></i>
@@ -177,26 +217,32 @@
                                 </a>
                                 <div class="collapse" id="manageExpense">
                                     <ul class="nav-second-level">
+                                        @if (Auth::user()->can('expense.add'))
                                         <li>
                                             <a href="{{ route('add.expense') }}">Add Expense</a>
                                         </li>
-
+                                        @endif
+                                        @if (Auth::user()->can('expense.today'))
                                         <li>
                                             <a href="{{ route('today.expense') }}">Today's Expense</a>
                                         </li>
-
+                                        @endif
+                                        @if (Auth::user()->can('expense.month'))
                                         <li>
                                             <a href="{{ route('month.expense') }}">Monthly Expense</a>
                                         </li>
-
+                                        @endif
+                                        @if (Auth::user()->can('expense.year'))
                                         <li>
                                             <a href="{{ route('year.expense') }}">Yearly Expense</a>
                                         </li>
-                                        
+                                        @endif
                                     </ul>
                                 </div>
                             </li>
+                            @endif
 
+                            @if (Auth::user()->can('orders.menu'))
                             <li>
                                 <a href="#manageInvoices" data-bs-toggle="collapse">
                                     <i class="mdi mdi-file-document-multiple"></i>
@@ -205,17 +251,22 @@
                                 </a>
                                 <div class="collapse" id="manageInvoices">
                                     <ul class="nav-second-level">
+                                        @if (Auth::user()->can('orders.pending'))
                                         <li>
                                             <a href="{{ route('pending.order') }}">Pending Orders</a>
                                         </li>
-
+                                        @endif
+                                        @if (Auth::user()->can('orders.complete'))
                                         <li>
                                             <a href="{{ route('completed.order') }}">Completed Orders</a>
                                         </li> 
+                                        @endif
                                     </ul>
                                 </div>
                             </li>
+                            @endif
 
+                            @if (Auth::user()->can('stock.menu'))
                             <li>
                                 <a href="#manageStocks" data-bs-toggle="collapse">
                                     <i class="mdi mdi-package-variant"></i>
@@ -224,13 +275,17 @@
                                 </a>
                                 <div class="collapse" id="manageStocks">
                                     <ul class="nav-second-level">
+                                        @if (Auth::user()->can('stock.all'))
                                         <li>
                                             <a href="{{ route('manage.stocks') }}">Stocks</a>
                                         </li>
+                                        @endif
                                     </ul>
                                 </div>
                             </li>
+                            @endif
 
+                            @if (Auth::user()->can('roles.menu'))
                             <li>
                                 <a href="#manageRPS" data-bs-toggle="collapse">
                                     <i class="mdi mdi-shield-account-variant"></i>
@@ -239,69 +294,61 @@
                                 </a>
                                 <div class="collapse" id="manageRPS">
                                     <ul class="nav-second-level">
+                                        @if (Auth::user()->can('roles.permission.all'))
                                         <li>
                                             <a href="{{ route('all.permission') }}">All Permission</a>
                                         </li>
+                                        @endif
+                                        @if (Auth::user()->can('roles.all'))
                                         <li>
                                             <a href="{{ route('all.roles') }}">All Roles</a>
                                         </li>
+                                        @endif
+                                        @if (Auth::user()->can('roles.in.permission.add'))
                                         <li>
                                             <a href="{{ route('add.roles.permission') }}">Add Roles in Permission</a>
                                         </li>
+                                        @endif
+                                        @if (Auth::user()->can('roles.in.permission.all'))
                                         <li>
                                             <a href="{{ route('all.roles.permission') }}">All Roles in Permission</a>
                                         </li>
+                                        @endif
                                     </ul>
                                 </div>
                             </li>
+                            @endif
 
+                            @if (Auth::user()->can('admin.menu'))
                             <li>
                                 <a href="#admin" data-bs-toggle="collapse">
-                                    <i class="mdi mdi-shield-account-variant"></i>
+                                    <i class="mdi mdi-account-switch"></i>
                                     <span> Admin User Role Settings </span>
                                     <span class="menu-arrow"></span>
                                 </a>
                                 <div class="collapse" id="admin">
                                     <ul class="nav-second-level">
+                                        @if (Auth::user()->can('admin.all'))
                                         <li>
                                             <a href="{{ route('all.admin') }}">All Admin</a>
                                         </li>
+                                        @endif
+                                        @if (Auth::user()->can('admin.add'))
                                         <li>
                                             <a href="{{ route('add.admin') }}">Add Admin</a>
                                         </li>
-                                        
+                                        @endif
                                     </ul>
                                 </div>
                             </li>
+                            @endif
 
-                            <li>
-                                <a href="#sidebarEmail" data-bs-toggle="collapse">
-                                    <i class="mdi mdi-email-multiple-outline"></i>
-                                    <span> Email </span>
-                                    <span class="menu-arrow"></span>
-                                </a>
-                                <div class="collapse" id="sidebarEmail">
-                                    <ul class="nav-second-level">
-                                        <li>
-                                            <a href="email-inbox.html">Inbox</a>
-                                        </li>
-                                        <li>
-                                            <a href="email-read.html">Read Email</a>
-                                        </li>
-                                        <li>
-                                            <a href="email-compose.html">Compose Email</a>
-                                        </li>
-                                        <li>
-                                            <a href="email-templates.html">Email Templates</a>
-                                        </li>
-                                    </ul>
-                                </div>
-                            </li>
+                            
 
 
                           
 
-                            <li class="menu-title mt-2">Custom</li>
+                            {{-- <li class="menu-title mt-2">Custom</li>
 
                             <li>
                                 <a href="#sidebarAuth" data-bs-toggle="collapse">
@@ -337,7 +384,7 @@
                                         </li>
                                     </ul>
                                 </div>
-                            </li>
+                            </li> --}}
 
                         </ul>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,92 +42,92 @@ Route::middleware('auth')->group(function () {
     Route::post('/update/password', [AdminController::class, 'UpdatePassword'])->name('update.password');
 
     Route::controller(EmployeeController::class)->group(function(){
-        Route::get('/all/employee', 'AllEmployee')->name('all.employee'); 
-        Route::get('/add/employee', 'AddEmployee')->name('add.employee');
+        Route::get('/all/employee', 'AllEmployee')->name('all.employee')->middleware('permission:employee.all'); 
+        Route::get('/add/employee', 'AddEmployee')->name('add.employee')->middleware('permission:employee.add');
         Route::post('/store/employee', 'StoreEmployee')->name('employee.store'); 
-        Route::get('/edit/employee/{id}', 'EditEmployee')->name('edit.employee');
+        Route::get('/edit/employee/{id}', 'EditEmployee')->name('edit.employee')->middleware('permission:employee.edit');
         Route::post('/update/employee', 'UpdateEmployee')->name('employee.update');
-        Route::get('/delete/employee/{id}', 'DeleteEmployee')->name('delete.employee');
+        Route::get('/delete/employee/{id}', 'DeleteEmployee')->name('delete.employee')->middleware('permission:employee.delete');
     });
 
     Route::controller(CustomerController::class)->group(function(){
-        Route::get('/all/customer', 'AllCustomer')->name('all.customer'); 
-        Route::get('/add/customer', 'AddCustomer')->name('add.customer');  
+        Route::get('/all/customer', 'AllCustomer')->name('all.customer')->middleware('permission:customer.all');
+        Route::get('/add/customer', 'AddCustomer')->name('add.customer')->middleware('permission:customer.add');  
         Route::post('/store/customer', 'CustomerStore')->name('customer.store');
-        Route::get('/edit/customer/{id}', 'EditCustomer')->name('edit.customer');  
+        Route::get('/edit/customer/{id}', 'EditCustomer')->name('edit.customer')->middleware('permission:customer.edit');
         Route::post('/update/customer', 'UpdateCustomer')->name('customer.update'); 
-        Route::get('/delete/customer/{id}', 'DeleteCustomer')->name('delete.customer');
+        Route::get('/delete/customer/{id}', 'DeleteCustomer')->name('delete.customer')->middleware('permission:customer.delete');
     });
 
     Route::controller(SupplierController::class)->group(function(){
-        Route::get('/all/supplier', 'AllSupplier')->name('all.supplier');
-        Route::get('/add/supplier', 'AddSupplier')->name('add.supplier'); 
+        Route::get('/all/supplier', 'AllSupplier')->name('all.supplier')->middleware('permission:supplier.all');
+        Route::get('/add/supplier', 'AddSupplier')->name('add.supplier')->middleware('permission:supplier.add');
         Route::post('/supplier/store', 'SupplierStore')->name('supplier.store');
-        Route::get('/edit/supplier/{id}', 'EditSupplier')->name('edit.supplier'); 
+        Route::get('/edit/supplier/{id}', 'EditSupplier')->name('edit.supplier')->middleware('permission:supplier.edit');
         Route::post('/update/supplier', 'UpdateSupplier')->name('supplier.update');
-        Route::get('/delete/supplier/{id}', 'DeletesSupplier')->name('delete.supplier');
+        Route::get('/delete/supplier/{id}', 'DeletesSupplier')->name('delete.supplier')->middleware('permission:supplier.delete');
         Route::get('/supplier/details/{id}', 'DetailsSupplier')->name('details.supplier');
     });
 
     Route::controller(SalaryController::class)->group(function(){
-        Route::get('/add/advance/salary', 'AddAdvanceSalary')->name('add.advance.salary');
-        Route::get('/all/advance/salary', 'AllAdvanceSalary')->name('all.advance.salary');  
+        Route::get('/add/advance/salary', 'AddAdvanceSalary')->name('add.advance.salary')->middleware('permission:salary.add');
+        Route::get('/all/advance/salary', 'AllAdvanceSalary')->name('all.advance.salary')->middleware('permission:salary.all');  
         Route::post('/advance/salary/store', 'AdvanceSalaryStore')->name('advance.salary.store');
-        Route::get('/edit/advance/salary/{id}', 'EditAdvanceSalary')->name('edit.advance.salary');
+        Route::get('/edit/advance/salary/{id}', 'EditAdvanceSalary')->name('edit.advance.salary')->middleware('permission:salary.edit');
         Route::post('/update/advance/salary', 'AdvanceSalaryUpdate')->name('advance.salary.update');
-        Route::get('/delete/advance/salary/{id}', 'DeleteAdvanceSalary')->name('delete.advance.salary');
+        Route::get('/delete/advance/salary/{id}', 'DeleteAdvanceSalary')->name('delete.advance.salary')->middleware('permission:salary.delete');
     });
 
     Route::controller(SalaryController::class)->group(function(){
-        Route::get('/pay/salary', 'PaySalary')->name('pay.salary');
-        Route::get('/pay/salary/now/{id}', 'PaySalaryNow')->name('pay.salary.now');
+        Route::get('/pay/salary', 'PaySalary')->name('pay.salary')->middleware('permission:salary.pay');
+        Route::get('/pay/salary/now/{id}', 'PaySalaryNow')->name('pay.salary.now')->middleware('permission:salary.pay.now');
         Route::post('/employee/salary/store', 'EmployeeSalaryStore')->name('employee.salary.store');
-        Route::get('/month/salary', 'MonthSalary')->name('month.salary');
+        Route::get('/month/salary', 'MonthSalary')->name('month.salary')->middleware('permission:salary.month');
     });
 
     Route::controller(AttendanceController::class)->group(function(){
-        Route::get('/employee/attendance/list', 'EmployeeAttendanceList')->name('employee.attendance.list');
-        Route::get('/add/employee/attendance', 'AddEmployeeAttendance')->name('add.employee.attendance');
+        Route::get('/employee/attendance/list', 'EmployeeAttendanceList')->name('employee.attendance.list')->middleware('permission:attendance.list');
+        Route::get('/add/employee/attendance', 'AddEmployeeAttendance')->name('add.employee.attendance')->middleware('permission:attendance.add');
         Route::post('/employee/attendance/store', 'EmployeeAttendanceStore')->name('employee.attendance.store');
-        Route::get('/edit/employee/attendance/{date}', 'EditEmployeeAttendance')->name('employee.attendance.edit');
+        Route::get('/edit/employee/attendance/{date}', 'EditEmployeeAttendance')->name('employee.attendance.edit')->middleware('permission:attendance.edit');
         Route::get('/view/employee/attendance/{date}', 'ViewEmployeeAttendance')->name('employee.attendance.view');
     });
 
     Route::controller(ProductCategoryController::class)->group(function(){
-        Route::get('/all/product/category', 'AllProductCategory')->name('all.product.category'); 
+        Route::get('/all/product/category', 'AllProductCategory')->name('all.product.category')->middleware('permission:category.all'); 
         Route::post('/store/product/category', 'StoreProductCategory')->name('product.category.store');
-        Route::get('/edit/product/category/{id}', 'EditProductCategory')->name('edit.product.category');
+        Route::get('/edit/product/category/{id}', 'EditProductCategory')->name('edit.product.category')->middleware('permission:category.edit');
         Route::post('/update/product/category', 'UpdateProductCategory')->name('update.product.category'); 
-        Route::get('/delete/product/category/{id}', 'DeleteProductCategory')->name('delete.product.category');
+        Route::get('/delete/product/category/{id}', 'DeleteProductCategory')->name('delete.product.category')->middleware('permission:category.delete');
     });
 
     Route::controller(ProductController::class)->group(function(){
-        Route::get('/all/product', 'AllProduct')->name('all.product');
-        Route::get('/add/product', 'AddProduct')->name('add.product');
+        Route::get('/all/product', 'AllProduct')->name('all.product')->middleware('permission:product.all');
+        Route::get('/add/product', 'AddProduct')->name('add.product')->middleware('permission:product.add');
         Route::post('/store/product', 'StoreProduct')->name('product.store'); 
-        Route::get('/edit/product/{id}', 'EditProduct')->name('edit.product');
+        Route::get('/edit/product/{id}', 'EditProduct')->name('edit.product')->middleware('permission:product.edit');
         Route::post('/update/product', 'UpdateProduct')->name('product.update');
-        Route::get('/delete/product/{id}', 'DeleteProduct')->name('delete.product');
+        Route::get('/delete/product/{id}', 'DeleteProduct')->name('delete.product')->middleware('permission:product.delete');
 
-        Route::get('/barcode/product/{id}', 'BarcodeProduct')->name('barcode.product');
+        Route::get('/barcode/product/{id}', 'BarcodeProduct')->name('barcode.product')->middleware('permission:product.barcode');
 
-        Route::get('/import/product', 'ImportProduct')->name('import.product');
-        Route::get('/export', 'Export')->name('export');
+        Route::get('/import/product', 'ImportProduct')->name('import.product')->middleware('permission:product.import');
+        Route::get('/export', 'Export')->name('export')->middleware('permission:product.export');
         Route::post('/import', 'Import')->name('import');
     });
 
     Route::controller(ExpenseController::class)->group(function(){
-        Route::get('/add/expense', 'AddExpense')->name('add.expense');
+        Route::get('/add/expense', 'AddExpense')->name('add.expense')->middleware('permission:expense.add');
         Route::post('/store/expense', 'StoreExpense')->name('expense.store');
-        Route::get('/today/expense', 'TodayExpense')->name('today.expense');
-        Route::get('/edit/expense/{id}', 'EditExpense')->name('edit.expense');
+        Route::get('/today/expense', 'TodayExpense')->name('today.expense')->middleware('permission:expense.today');
+        Route::get('/edit/expense/{id}', 'EditExpense')->name('edit.expense')->middleware('permission:expense.edit');
         Route::post('/expense/update', 'UpdateExpense')->name('expense.update');
-        Route::get('/month/expense', 'MonthExpense')->name('month.expense');
-        Route::get('/year/expense', 'YearExpense')->name('year.expense');
+        Route::get('/month/expense', 'MonthExpense')->name('month.expense')->middleware('permission:expense.month');
+        Route::get('/year/expense', 'YearExpense')->name('year.expense')->middleware('permission:expense.year');
     });
 
     Route::controller(PosController::class)->group(function(){
-        Route::get('/pos', 'Pos')->name('pos');
+        Route::get('/pos', 'Pos')->name('pos')->middleware('permission:pos.new');
         Route::post('/add-cart', 'AddCart');
         Route::get('/allitem', 'AllItem');
         Route::post('/cart-update/{rowId}', 'CartUpdate');
@@ -137,48 +137,48 @@ Route::middleware('auth')->group(function () {
 
     Route::controller(OrderController::class)->group(function(){
         Route::post('/final-invoice', 'FinalInvoice');
-        Route::get('/pending/order', 'PendingOrder')->name('pending.order');
-        Route::get('/completed/order', 'CompletedOrder')->name('completed.order');
-        Route::get('/order/details/{order_id}', 'OrderDetails')->name('order.details');
+        Route::get('/pending/order', 'PendingOrder')->name('pending.order')->middleware('permission:orders.pending');
+        Route::get('/completed/order', 'CompletedOrder')->name('completed.order')->middleware('permission:orders.complete');
+        Route::get('/order/details/{order_id}', 'OrderDetails')->name('order.details')->middleware('permission:orders.detail');
         Route::post('/order/status/update', 'OrderStatusUpdate')->name('order.status.update');
-        Route::get('/manage/stocks', 'ManageStocks')->name('manage.stocks');
-        Route::get('/order/invoice-download/{order_id}', 'OrderInvoiceDownload');
+        Route::get('/manage/stocks', 'ManageStocks')->name('manage.stocks')->middleware('permission:stock.all');
+        Route::get('/order/invoice-download/{order_id}', 'OrderInvoiceDownload')->middleware('permission:orders.pdf.download');
     });
 
     Route::controller(RoleController::class)->group(function(){
-        Route::get('/all/permission', 'AllPermission')->name('all.permission');
-        Route::get('/add/permission', 'AddPermission')->name('add.permission');
+        Route::get('/all/permission', 'AllPermission')->name('all.permission')->middleware('permission:roles.permission.all');
+        Route::get('/add/permission', 'AddPermission')->name('add.permission')->middleware('permission:roles.permission.add');
         Route::post('/permission/store', 'StorePermission')->name('permission.store');
-        Route::get('/edit/permission/{id}', 'EditPermission')->name('edit.permission');
+        Route::get('/edit/permission/{id}', 'EditPermission')->name('edit.permission')->middleware('permission:roles.permission.edit');
         Route::post('/permission/update', 'UpdatePermission')->name('permission.update');
-        Route::get('/delete/permission/{id}', 'DeletePermission')->name('delete.permission');
+        Route::get('/delete/permission/{id}', 'DeletePermission')->name('delete.permission')->middleware('permission:roles.permission.delete');
     });
 
     Route::controller(RoleController::class)->group(function(){
-        Route::get('/all/roles', 'AllRoles')->name('all.roles');
-        Route::get('/add/role', 'AddRole')->name('add.role');
+        Route::get('/all/roles', 'AllRoles')->name('all.roles')->middleware('permission:roles.all');
+        Route::get('/add/role', 'AddRole')->name('add.role')->middleware('permission:roles.all.add');
         Route::post('/store/role', 'StoreRole')->name('role.store');
-        Route::get('/edit/role/{id}', 'EditRole')->name('edit.role');
+        Route::get('/edit/role/{id}', 'EditRole')->name('edit.role')->middleware('permission:roles.all.edit');
         Route::post('/update/role', 'UpdateRole')->name('role.update');
-        Route::get('/delete/role/{id}', 'DeleteRole')->name('delete.role');
+        Route::get('/delete/role/{id}', 'DeleteRole')->name('delete.role')->middleware('permission:roles.all.delete');
     });
 
     Route::controller(RoleController::class)->group(function(){
-        Route::get('/add/roles/permission', 'AddRolesPermission')->name('add.roles.permission');
+        Route::get('/add/roles/permission', 'AddRolesPermission')->name('add.roles.permission')->middleware('permission:roles.in.permission.add');
         Route::post('/role/permission/store', 'RolePermissionStore')->name('role.permission.store');
-        Route::get('/all/roles/permission', 'AllRolesPermission')->name('all.roles.permission');
-        Route::get('/edit/role/permission/{id}', 'EditRolesPermission')->name('edit.role.permission');
-        Route::post('/update/role/permission/{id}', 'UpdateRolesPermission')->name('role.permission.update'); 
-        Route::get('/delete/role/permission/{id}', 'DeleteRolesPermission')->name('delete.role.permission'); 
+        Route::get('/all/roles/permission', 'AllRolesPermission')->name('all.roles.permission')->middleware('permission:roles.in.permission.all');
+        Route::get('/edit/role/permission/{id}', 'EditRolesPermission')->name('edit.role.permission')->middleware('permission:roles.in.permission.edit');
+        Route::post('/update/role/permission/{id}', 'UpdateRolesPermission')->name('role.permission.update');
+        Route::get('/delete/role/permission/{id}', 'DeleteRolesPermission')->name('delete.role.permission')->middleware('permission:roles.in.permission.delete'); 
     });
 
     Route::controller(AdminController::class)->group(function(){
-        Route::get('/all/admin', 'AllAdmin')->name('all.admin');
-        Route::get('/add/admin', 'AddAdmin')->name('add.admin');
+        Route::get('/all/admin', 'AllAdmin')->name('all.admin')->middleware('permission:admin.all');
+        Route::get('/add/admin', 'AddAdmin')->name('add.admin')->middleware('permission:admin.add');
         Route::post('/admin/store', 'StoreAdmin')->name('admin.store');
-        Route::get('/edit/admin/{id}', 'EditAdmin')->name('edit.admin');
+        Route::get('/edit/admin/{id}', 'EditAdmin')->name('edit.admin')->middleware('permission:admin.edit');
         Route::post('/admin/update', 'UpdateAdmin')->name('admin.update');
-        Route::get('/delete/admin/{id}', 'DeleteAdmin')->name('delete.admin');
+        Route::get('/delete/admin/{id}', 'DeleteAdmin')->name('delete.admin')->middleware('permission:admin.delete');
 
     });
 


### PR DESCRIPTION
Introduced `middleware` `aliases` for `role and permission` checks in `bootstrap/app.php`. Updated all relevant Blade views to conditionally display UI elements based on `user permissions`. Modified `routes/web.php` to apply `permission middleware` to all resource routes, enforcing granular access control throughout the application. Also added 'admin' to `permission group` options and made minor UI label adjustments in the sidebar.